### PR TITLE
CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
         sudo apt install mingw-w64
         sudo apt install mingw-w64-x86-64-dev
 
+    # Reference: https://github.com/actions/cache/blob/main/examples.md#go---modules
+    - name: Go cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-
+
     - name: Linux build
       run: make linux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19
+        check-latest: true
+        cache: true
 
     - name: Install dependency (Linux)
       run: |
@@ -23,16 +25,6 @@ jobs:
       run: |
         sudo apt install mingw-w64
         sudo apt install mingw-w64-x86-64-dev
-
-    # Reference: https://github.com/actions/cache/blob/main/examples.md#go---modules
-    - name: Go cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-
 
     - name: Linux build
       run: make linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,19 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19
-    
-    - name: Linux build
+
+    - name: Install dependency (Linux)
       run: |
         sudo apt update 
         sudo apt install libgl1-mesa-dev xorg-dev
-        make linux
+
+    - name: Install dependency (Windows)
+      run: |
+        sudo apt install mingw-w64
+        sudo apt install mingw-w64-x86-64-dev
+
+    - name: Linux build
+      run: make linux
 
     - name: Archive Linux executable file
       uses: actions/upload-artifact@v3
@@ -26,10 +33,7 @@ jobs:
         path: linux-generator
 
     - name: Windows build (Cross compile)
-      run: |
-        sudo apt install mingw-w64
-        sudo apt install mingw-w64-x86-64-dev
-        make windows
+      run: make windows
 
     - name: Archive Windows executable file
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
- CI: Separate package installation to other steps
- CI: Add Golang package cache
- CI: Use simpler yaml for caching