### PR TITLE
CI: Add apt cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
         cache: true
 
     - name: Install dependency
-      run: |
-        sudo apt update
-        sudo apt install libgl1-mesa-dev xorg-dev
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libgl1-mesa-dev xorg-dev
+        version: 1
 
     - name: Build
       run: make linux
@@ -46,10 +47,13 @@ jobs:
         cache: true
 
     - name: Install dependency
-      run: |
-        sudo apt update
-        sudo apt install libgl1-mesa-dev xorg-dev
-        sudo apt install mingw-w64 mingw-w64-x86-64-dev
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libgl1-mesa-dev xorg-dev
+        version: 1
+
+    - name: Install dependency without cache
+      run: sudo apt install mingw-w64 mingw-w64-x86-64-dev
 
     - name: Build (Cross compile)
       run: make windows


### PR DESCRIPTION
The mingw-w64 and mingw-w64-x86-64-dev package can not be cached.
This should be retried in the future when the cache-apt-pkgs-action has new version.